### PR TITLE
Mimic the liquibase standard load/parse by setting the objectQuotingStrategy

### DIFF
--- a/src/main/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegate.groovy
+++ b/src/main/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegate.groovy
@@ -83,6 +83,14 @@ class DatabaseChangeLogDelegate {
 			}
 		}
 
+		if( objectQuotingStrategy == null ){
+			objectQuotingStrategy= databaseChangeLog.objectQuotingStrategy
+		}
+
+		if( objectQuotingStrategy == null ){
+			objectQuotingStrategy= ObjectQuotingStrategy.LEGACY
+		}
+
 		def changeSet = new ChangeSet(
 				DelegateUtil.expandExpressions(params.id, databaseChangeLog),
 				DelegateUtil.expandExpressions(params.author, databaseChangeLog),


### PR DESCRIPTION
Mimic the liquibase standard load/parse by setting the changeSet's objectQuotingStrategy from the changeLog one. Else changeSet got null instead of LEGACY which seems to be the default. 
On MySQL and SQLSever is fine but I found problems with Postgresql as it uncapitalize non quoted identifiers. 