### PR TITLE
updates org.codehaus.groovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ repositories {
 
 
 dependencies {
-  compile 'org.codehaus.groovy:groovy:2.4.4'
-  compile 'org.codehaus.groovy:groovy-sql:2.4.4'
+  compile 'org.codehaus.groovy:groovy:2.4.15'
+  compile 'org.codehaus.groovy:groovy-sql:2.4.15'
   // This seems redundant, but it isn't.  We need compileOnly so that the main
   // classes will compile, but that dependency doesn't transfer to the unit
   // tests, so we also need testCompile.

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ repositories {
 
 
 dependencies {
-  compile 'org.codehaus.groovy:groovy:2.4.15'
-  compile 'org.codehaus.groovy:groovy-sql:2.4.15'
+  compile 'org.codehaus.groovy:groovy:2.4.12'
+  compile 'org.codehaus.groovy:groovy-sql:2.4.12'
   // This seems redundant, but it isn't.  We need compileOnly so that the main
   // classes will compile, but that dependency doesn't transfer to the unit
   // tests, so we also need testCompile.

--- a/liquibase.gradle
+++ b/liquibase.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-  runtime 'org.codehaus.groovy:groovy:2.4.15'
-  runtime 'org.codehaus.groovy:groovy-sql:2.4.15'
+  runtime 'org.codehaus.groovy:groovy:2.4.12'
+  runtime 'org.codehaus.groovy:groovy-sql:2.4.12'
   runtime 'org.liquibase:liquibase-core:3.4.2'
   runtime 'mysql:mysql-connector-java:5.1.34'
 }

--- a/liquibase.gradle
+++ b/liquibase.gradle
@@ -6,8 +6,8 @@ repositories {
 }
 
 dependencies {
-  runtime 'org.codehaus.groovy:groovy:2.4.1'
-  runtime 'org.codehaus.groovy:groovy-sql:2.4.1'
+  runtime 'org.codehaus.groovy:groovy:2.4.15'
+  runtime 'org.codehaus.groovy:groovy-sql:2.4.15'
   runtime 'org.liquibase:liquibase-core:3.4.2'
   runtime 'mysql:mysql-connector-java:5.1.34'
 }


### PR DESCRIPTION
Hi @stevesaliman 
I need this upgrade because according to our NexusIQ scans the following dependency has a security threat:
> CVE-2016-6814 :arrow_right:  org.codehaus.groovy : groovy : 2.4.4