### PR TITLE
Support Groovy 4

### DIFF
--- a/src/main/groovy/liquibase/parser/ext/GroovyLiquibaseChangeLogParser.groovy
+++ b/src/main/groovy/liquibase/parser/ext/GroovyLiquibaseChangeLogParser.groovy
@@ -126,7 +126,7 @@ class GroovyLiquibaseChangeLogParser implements ChangeLogParser {
 
         delegate.resourceAccessor = resourceAccessor
         closure.delegate = delegate
-        closure.resolveStrategy = Closure.OWNER_FIRST
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure.call()
     }
 }


### PR DESCRIPTION
Groovy 4 no longer allows us to handle missing methods in the same way as before. See #52 for details.

I have chosen the most simple fix here, which is to set the resolve strategy for the `ChangeLogParser` to `DELEGATE_FIRST` , which is where the methods are found. This makes it work with Groovy 4, and it shouldn't affect Groovy 2 or 3 users as it only determines where to look for methods first. This is also the strategy that is used in the other parsers, so I am unsure if there is a good reason for it to be set to `OWNER_FIRST` to begin with.

It would probably be better to go away from using the "methodMissing" methods entirely, or make them throw `MissingMethodException` instead of custom exceptions. But I found that to be too big a change for this issue and the `DELEGATE_FIRST` strategy seems more correct in any case.

Fixes #52 