### PR TITLE
Improving ModifySqlDelegate

### DIFF
--- a/src/main/groovy/org/liquibase/groovy/delegate/ModifySqlDelegate.groovy
+++ b/src/main/groovy/org/liquibase/groovy/delegate/ModifySqlDelegate.groovy
@@ -107,7 +107,7 @@ class ModifySqlDelegate {
             sqlVisitor.applicableDbms = modifySqlDbmsList
         }
         if ( modifySqlContexts ) {
-            sqlVisitor.contexts = modifySqlContexts
+            sqlVisitor.contextFilter = modifySqlContexts
         }
         if ( modifySqlLabels ) {
             sqlVisitor.labels = modifySqlLabels


### PR DESCRIPTION
migrate to contextFilter.
because, deprecated method.

https://github.com/liquibase/liquibase/blob/831135b58ef12a99cbb7b5a7a66539d680193b47/liquibase-standard/src/main/java/liquibase/sql/visitor/AbstractSqlVisitor.java#L54-L60