### PR TITLE
Support onSqlOutput on Preconditions

### DIFF
--- a/src/main/groovy/org/liquibase/groovy/delegate/PreconditionDelegate.groovy
+++ b/src/main/groovy/org/liquibase/groovy/delegate/PreconditionDelegate.groovy
@@ -161,6 +161,9 @@ class PreconditionDelegate {
             } else if ( key == "onError" ) {
                 preconditions.onError = ErrorOption."${paramValue}"
             } else if ( key == "onUpdateSQL" ) {
+                println "Warning: ChangeSet '${changeSetId}': onUpdateSQL parameter has been deprecated, and may be removed in a future release. Please use onUpdateSql instead of onSqlOuptut."
+                preconditions.onSqlOutput = OnSqlOutputOption."${paramValue}"
+            } else if ( key == "onSqlOutput" ) {
                 preconditions.onSqlOutput = OnSqlOutputOption."${paramValue}"
             } else {
                 // pass the reset to Liquibase

--- a/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateTests.groovy
+++ b/src/test/groovy/org/liquibase/groovy/delegate/DatabaseChangeLogDelegateTests.groovy
@@ -157,9 +157,34 @@ databaseChangeLog()
 
 
     @Test
-    void preconditionParameters() {
+    void preconditionParametersWithOnUpdateSQL() {
         def closure = {
             preConditions(onFail: 'WARN', onError: 'MARK_RAN', onUpdateSQL: 'TEST', onFailMessage: 'fail-message!!!1!!1one!', onErrorMessage: 'error-message') {
+
+            }
+        }
+
+        def databaseChangeLog = new DatabaseChangeLog('changelog.xml')
+        databaseChangeLog.changeLogParameters = new ChangeLogParameters()
+        def delegate = new DatabaseChangeLogDelegate(databaseChangeLog)
+        closure.delegate = delegate
+        closure.call()
+
+        // Liquibase now wraps the container in a container.  I don't know why.
+        def preconditions = databaseChangeLog.preconditions.nestedPreconditions[0]
+        assertNotNull preconditions
+        assertTrue preconditions instanceof PreconditionContainer
+        assertEquals PreconditionContainer.FailOption.WARN, preconditions.onFail
+        assertEquals PreconditionContainer.ErrorOption.MARK_RAN, preconditions.onError
+        assertEquals PreconditionContainer.OnSqlOutputOption.TEST, preconditions.onSqlOutput
+        assertEquals 'fail-message!!!1!!1one!', preconditions.onFailMessage
+        assertEquals 'error-message', preconditions.onErrorMessage
+    }
+
+    @Test
+    void preconditionParametersWithOnSqlOutput() {
+        def closure = {
+            preConditions(onFail: 'WARN', onError: 'MARK_RAN', onSqlOutput: 'TEST', onFailMessage: 'fail-message!!!1!!1one!', onErrorMessage: 'error-message') {
 
             }
         }


### PR DESCRIPTION
replace to onSqlOutput from onUpdateSql.

### reason1. onUpdateSql is for formatted SQL. shouldBe use onSqlOutput in  XML, YAML, and JSON format.

https://docs.liquibase.com/concepts/changelogs/preconditions.html

> onSqlOutput	Controls how preconditions are evaluated with the update-sql command for XML, YAML, and JSON changelogs. Since 1.9.5
> onUpdateSql	Controls how preconditions are evaluated with the update-sql command for formatted SQL changelogs.

### reason2. now allowed onUpdateSQL in XML. groovy dsl is the alternative of XML format.

https://github.com/liquibase/liquibase/blob/4ffdc8d559355d1d70b352ae63fe585a62cb20ac/liquibase-standard/src/main/resources/www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd#L190-L202

